### PR TITLE
Fix/1

### DIFF
--- a/src/frontend/src/routes/+page.svelte
+++ b/src/frontend/src/routes/+page.svelte
@@ -3,6 +3,7 @@
 	import { authStore } from '$lib/stores/auth.store';
 	import { AuthClient } from '@dfinity/auth-client';
 	import { createActor } from '../../../declarations/backend';
+	import { onMount } from 'svelte';
 
 	let input = '';
 	let disabled = false;
@@ -30,18 +31,13 @@
 		disabled = false;
 	};
 
-	// Safari double clicks issues with the AuthButton component can be fixed temporarily with below hack
-	// let calledAuthClientOnceInSafari = false;
-	// onMount(async () => {
-	// 	try {
-	// 		if (/apple/i.test(navigator?.vendor) && !calledAuthClientOnceInSafari) {
-	// 			await authStore.signIn({ domain: 'internetcomputer.org' });
-	// 			calledAuthClientOnceInSafari = true;
-	// 		}
-	// 	} catch (error) {
-	// 		console.error('Sign in error:', error);
-	// 	}
-	// });
+	onMount(async () => {
+		try {
+			await authStore.sync();
+		} catch (error) {
+			console.error('Sign in error:', error);
+		}
+	});
 </script>
 
 <main>

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -1,7 +1,7 @@
 import adapter from '@sveltejs/adapter-static';
 import autoprefixer from 'autoprefixer';
 import { readFileSync } from 'fs';
-import preprocess from 'svelte-preprocess';
+import { sveltePreprocess } from 'svelte-preprocess';
 import { fileURLToPath } from 'url';
 
 const file = fileURLToPath(new URL('package.json', import.meta.url));
@@ -14,7 +14,7 @@ const filesPath = (path) => `src/frontend/${path}`;
 const config = {
 	// Consult https://github.com/sveltejs/svelte-preprocess
 	// for more information about preprocessors
-	preprocess: preprocess({
+	preprocess: sveltePreprocess({
 		postcss: {
 			plugins: [autoprefixer]
 		}


### PR DESCRIPTION
-Fixing Safari SignIn button bug `double click to signin bug`.
-`preprocess` deprecated. Using `sveltePreprocess` now